### PR TITLE
夏季开源成长营 【1-1~1-12】docs: add sample code tutorials for tasks 1-1 through 1-12

### DIFF
--- a/贡献内容/任务1-10-AMOP订阅消息样例源码走读.md
+++ b/贡献内容/任务1-10-AMOP订阅消息样例源码走读.md
@@ -1,0 +1,151 @@
+# AMOP 订阅消息样例源码走读
+
+> **源码文件**: [subscribe.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/amop/subscribe.cpp)
+> **代码行数**: 101行
+> **核心功能**: 通过 AMOP 协议订阅 Topic，接收消息后 echo 回复给发布方
+
+---
+
+## 任务目标
+
+讲清三个核心流程：**Topic 订阅机制**、**消息回调处理逻辑**、**`sendResponse` 响应发送的完整链路**。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-37 | 头文件引入 + namespace |
+| 39-46 | `usage()` 帮助信息 |
+| 48-62 | 参数解析 + Topic 集合收集 |
+| 64-92 | **核心：setSubCallback + subscribe** |
+| 94-100 | 主循环保活 |
+
+---
+
+## 二、分步走读
+
+### 第1步：多 Topic 支持（行56-61）
+
+```cpp
+// ./subscribe ./config_sample.ini topic1 topic2 topic3 ...
+
+std::set<std::string> topicList;
+for (int i = 2; i < argc; i++) {
+    topicList.insert(argv[i]);     // 使用 std::set 去重
+}
+std::string topic = argv[2];       // 保存第一个 topic 用于日志
+```
+
+使用 `std::set` 收集 Topic，自动去重。与 publish 端一次只能发一个 Topic 不同，subscribe 端可**同时订阅多个**。
+
+### 第2步（核心）：setSubCallback + sendResponse（行74-91）
+
+```cpp
+sdk->amop()->setSubCallback(
+    [&sdk](Error::Ptr _error,                          // 参数1: 错误
+           const std::string& _endPoint,                // 参数2: 发布方节点标识
+           const std::string& _seq,                     // 参数3: 消息序列号
+           bytesConstRef _data,                         // 参数4: 消息体
+           std::shared_ptr<WsSession> _session) {       // 参数5: WebSocket 会话
+
+        if (_error) {
+            std::cout << "something is wrong"
+                      << " code: " << _error->errorCode()
+                      << " message: " << _error->errorMessage() << std::endl;
+        } else {
+            std::cout << "recv message and would echo message ===>>>> "
+                      << "endPoint: " << _endPoint
+                      << " msg: " << std::string(_data.begin(), _data.end())
+                      << std::endl;
+
+            // ★ echo 回复
+            sdk->amop()->sendResponse(_endPoint, _seq, _data);
+        }
+    }
+);
+```
+
+**回调只有 5 个参数**（无 `WsMessage`、`LocalTopic`、`P2PMessage`）：
+
+| 参数 | 类型 | 含义 |
+|------|------|------|
+| `_error` | `Error::Ptr` | 错误信息 |
+| `_endPoint` | `const string&` | 发布方节点标识 |
+| `_seq` | `const string&` | 消息序列号，用于匹配请求-响应 |
+| `_data` | `bytesConstRef` | 消息体（零拷贝） |
+| `_session` | `shared_ptr<WsSession>` | WebSocket 会话对象 |
+
+**sendResponse 三要素**：
+
+```cpp
+sdk->amop()->sendResponse(_endPoint,  // 发布方节点标识
+                          _seq,       // 消息序列号
+                          _data);     // echo 原消息体
+```
+
+本例中直接 echo 原消息，实际应用可返回业务处理结果。这三个参数必须与接收到的值一一对应。
+
+### 第3步：订阅 Topic（行92）
+
+```cpp
+sdk->amop()->subscribe(topicList);    // 传入 set<string>
+```
+
+**先 setSubCallback，再 subscribe**。顺序颠倒会导致窗口期的消息丢失。
+
+---
+
+## 三、运行方法
+
+```bash
+# 订阅单个 Topic
+./subscribe ./config_sample.ini myTopic
+
+# 订阅多个 Topic
+./subscribe ./config_sample.ini topic1 topic2 topic3
+```
+
+配合测试：
+```bash
+# 终端1: 先启动订阅方
+./subscribe ./config_sample.ini myTopic
+
+# 终端2: 启动发布方
+./publish ./config_sample.ini myTopic "Hello AMOP"
+```
+
+---
+
+## 四、Subscribe 与 Publish 协作图
+
+```
+   Subscriber 端                        Publisher 端
+   ────────────                        ────────────
+setSubCallback(cb)                  publish(topic, data, -1, cb)
+subscribe(topicList)                      ↓
+     ↓                              等待响应...
+收到消息 → cb(_error, endPoint, seq, data, session)
+     ↓
+sendResponse(endPoint, seq, data)  ─────→  触发回调
+     ↓                                    _msg->payload() → 打印
+继续等待...
+```
+
+---
+
+## 五、关键 API
+
+| API | 作用 |
+|-----|------|
+| `Sdk::amop()->setSubCallback(cb)` | 设置消息接收回调（5 参数） |
+| `Sdk::amop()->subscribe(topicSet)` | 订阅 Topic 集合（`set<string>`） |
+| `Sdk::amop()->sendResponse(endPoint, seq, data)` | 向发布方回复消息 |
+| `Sdk::amop()->unSubscribe(topicSet)` | 取消订阅 |
+
+---
+
+## 小结
+
+`subscribe.cpp` 展示了 AMOP 订阅端的完整实现：**`std::set` 多 Topic 去重 → setSubCallback 注册 5 参数回调 → echo 原消息 sendResponse**。核心要点：回调参数无 WsMessage/LocalTopic/P2PMessage，`sendResponse` 三个参数直接取自回调中接收到的 `_endPoint`、`_seq`、`_data`。

--- a/贡献内容/任务1-11-AMOP广播消息样例源码走读.md
+++ b/贡献内容/任务1-11-AMOP广播消息样例源码走读.md
@@ -1,0 +1,126 @@
+# AMOP 广播消息样例源码走读
+
+> **源码文件**: [broadcast.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/amop/broadcast.cpp)
+> **代码行数**: 81行
+> **核心功能**: 通过 AMOP 协议向全网广播消息，不等待响应
+
+---
+
+## 任务目标
+
+讲清核心对比：**broadcast 的 Fire-and-Forget 模式与 publish 的 Request-Response 模式的区别**。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-37 | 头文件引入 + namespace |
+| 39-46 | `usage()` |
+| 48-69 | 参数校验 + SDK 初始化 |
+| 71-78 | **核心：while 循环中 `broadcast()` 调用** |
+
+---
+
+## 二、分步走读
+
+### 第1步：SDK 初始化（行48-69）
+
+```cpp
+// ./broadcast ./config_sample.ini topic msg
+if (argc < 4) usage();      // 三个参数均为必填
+
+std::string config = argv[1];
+std::string topic = argv[2];
+std::string msg = argv[3];
+
+auto factory = std::make_shared<SdkFactory>();
+auto sdk = factory->buildSdk(config);   // 字符串路径
+sdk->start();
+```
+
+消息参数 `msg` **必须提供**（`argc < 4`），没有默认值。
+
+### 第2步（核心）：broadcast() — 无回调推送（行71-78）
+
+```cpp
+while (true) {
+    sdk->amop()->broadcast(
+        topic,
+        bytesConstRef((byte*)msg.data(), msg.size())
+    );
+    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+}
+```
+
+**与 publish() 的关键差异**：
+
+| 维度 | `broadcast()` | `publish()` |
+|------|:---:|:---:|
+| 参数数量 | 2 | 4 |
+| 回调 | **无** | 3 参数回调 |
+| 等待响应 | **不等待**（Fire-and-Forget） | 等待（阻塞或超时） |
+| 通信模式 | 单向广播 | 双向请求-响应 |
+| 订阅方需 sendResponse | 不需要 | 需要 |
+
+**注意**：SDK 在 while 外创建一次后循环复用，与 publish 相同。
+
+---
+
+## 三、broadcast vs publish 核心代码对比
+
+**broadcast（发送即忘，2 参数）**：
+
+```cpp
+sdk->amop()->broadcast(topic, bytesConstRef((byte*)msg.data(), msg.size()));
+// 无回调，调用后立即返回
+```
+
+**publish（等待响应，4 参数）**：
+
+```cpp
+sdk->amop()->publish(
+    topic,
+    bytesConstRef((byte*)msg.data(), msg.size()),
+    -1,
+    [](Error::Ptr _error, shared_ptr<WsMessage> _msg, shared_ptr<WsSession> _session) {
+        if (_msg->status() == 0) {
+            cout << string(_msg->payload()->begin(), _msg->payload()->end());
+        }
+    }
+);
+```
+
+---
+
+## 四、适用场景对比
+
+| 场景 | 推荐模式 | 原因 |
+|------|---------|------|
+| 全链通知（新区块上线） | broadcast | 无需确认，所有节点收到即可 |
+| 系统公告 | broadcast | 一对多推送，无需回复 |
+| 日志聚合推送 | broadcast | 单向数据流，低延迟 |
+| 请求查询节点状态 | publish | 需要获取查询结果 |
+| 远程命令下发 | publish | 需要确认执行结果 |
+| 心跳检测 | publish | 需要对方响应确认存活 |
+
+---
+
+## 五、运行方法
+
+```bash
+./broadcast ./config_sample.ini myTopic "System notification"
+```
+
+| 参数 | 说明 |
+|------|------|
+| config_sample.ini | SDK 配置文件 |
+| myTopic | 广播 Topic |
+| "System notification" | 广播内容（必填） |
+
+---
+
+## 小结
+
+`broadcast.cpp` 是 AMOP 三个示例中最简洁的（81行），核心就一行 `broadcast(topic, data)`。与 `publish()` 的本质区别在于**通信模式**：broadcast 是单向 Fire-and-Forget，无回调不等响应；publish 是双向 Request-Response，通过 3 参数回调获取 subscribe 端的回复。选择哪个取决于是否需要响应确认。

--- a/贡献内容/任务1-12-Echo-Server网络样例源码走读.md
+++ b/贡献内容/任务1-12-Echo-Server网络样例源码走读.md
@@ -1,0 +1,147 @@
+# Echo Server 网络样例源码走读
+
+> **源码文件**: [echo_server_sample.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/fisco-bcos-demo/echo_server_sample.cpp)
+> **代码行数**: 78行
+> **核心功能**: 基于 Gateway 底层 P2P 接口实现的 Echo 服务器，将收到的消息直接原路返回
+
+---
+
+## 任务目标
+
+讲清三个核心要点：**Gateway 层初始化（与 SDK 层的区别）**、**自定义消息处理器的注册与回调机制**、**消息回显的极简实现**。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-27 | 头文件引入 |
+| 32-38 | `usage()` |
+| 40-57 | **核心：GatewayFactory 初始化 + Gateway 启动** |
+| 60-71 | **核心：registerHandlerByMsgType 注册回显处理器** |
+| 72-77 | 主循环保持 Gateway 运行 |
+
+---
+
+## 二、分步走读
+
+### 第1步：配置文件加载（行40-51）
+
+```cpp
+g_BCOSConfig.setCodec(std::make_shared<ProtocolInfoCodecImpl>());
+auto keyFactory = std::make_shared<KeyFactoryImpl>();
+auto nodeConfig = std::make_shared<NodeConfig>();
+
+std::string configFilePath = "config.ini";    // ★ 硬编码
+nodeConfig->loadConfig(configFilePath);
+
+boost::property_tree::ptree pt;
+boost::property_tree::read_ini(configFilePath, pt);
+auto logInitializer = std::make_shared<BoostLogInitializer>();
+logInitializer->initLog(pt);
+```
+
+配置文件路径**硬编码为 `"config.ini"`**，不通过命令行参数传入。`NodeConfig::loadConfig()` 负责解析 P2P 和 Gateway 相关配置。
+
+### 第2步（核心）：GatewayFactory 初始化（行53-57）
+
+```cpp
+GatewayFactory gatewayFactory(nodeConfig->chainId(), "localClient", nullptr);
+auto gateway = gatewayFactory.buildGateway(configFilePath, true, nullptr, "localClient");
+auto service = std::dynamic_pointer_cast<Service>(gateway->p2pInterface());
+gateway->start();
+```
+
+**与 SDK 初始化的关键差异**：
+
+| 维度 | SDK 示例（bcos-sdk/sample） | Echo 示例（fisco-bcos-demo） |
+|------|---------------------------|----------------------------|
+| 工厂类 | `SdkFactory` | `GatewayFactory` |
+| 构建产物 | `Sdk` 对象 | `Gateway` 对象 |
+| 通信层级 | RPC / AMOP（应用层） | P2P Session（传输层） |
+| 接口获取 | `sdk->service()` / `sdk->jsonRpc()` | `gateway->p2pInterface()` → `Service` |
+
+### 第3步（核心）：回显处理器（行60-71）
+
+```cpp
+service->registerHandlerByMsgType(
+    999,                    // 自定义消息类型编号
+    [](NetworkException _e,
+       std::shared_ptr<P2PSession> _session,
+       P2PMessage::Ptr _msg) {
+
+        if (_e.errorCode()) return;
+
+        _msg->setRespPacket();                    // ★ 直接标记为响应包
+        _session->session()->asyncSendMessage(_msg);  // ★ 原消息发回
+    }
+);
+```
+
+**回调只有 3 个参数**（无 `NodeID`、无单独 `bytes`）：
+
+| 参数 | 类型 | 含义 |
+|------|------|------|
+| `_e` | `NetworkException` | 异常信息，`errorCode()!=0` 则跳过 |
+| `_session` | `shared_ptr<P2PSession>` | P2P 会话 |
+| `_msg` | `P2PMessage::Ptr` | 收到的消息对象 |
+
+**极简回显逻辑**（两步）：
+
+1. `_msg->setRespPacket()` —— 在原有消息对象上标记为响应包
+2. `_session->session()->asyncSendMessage(_msg)` —— 原封不动发送回去
+
+**没有**创建新的 `P2PMessageFactory`，**没有** `setPayload()`，**没有**构建新消息——直接复用收到的 `_msg`。
+
+---
+
+## 三、运行方法
+
+```bash
+# 启动 Echo Server（需要当前目录有 config.ini）
+./echo-server-sample
+
+# 配合 echo_client 测试
+./echo-client-sample 100 127.0.0.1 30300 1024
+```
+
+---
+
+## 四、Echo 请求-响应流程图
+
+```
+     Echo Client                          Echo Server
+     ──────────                         ────────────
+  GatewayFactory::buildGateway()      GatewayFactory::buildGateway()
+         ↓                                    ↓
+  gateway->start()                     registerHandlerByMsgType(999, cb)
+         ↓                                    ↓
+  asyncSendMessageByEndPoint           等待 P2P 消息...
+    (msgType=999, payload=...)                ↓
+         ↓                           收到 msgType=999 → cb(_e, session, _msg)
+    等待响应...                              ↓
+         ↓                             _e.errorCode()==0
+    收到响应 ←───────────────────      _msg->setRespPacket()
+         ↓                             asyncSendMessage(_msg)  ← 回显
+  receiveResponse                            ↓
+                                         继续等待...
+```
+
+---
+
+## 五、与 SDK 层编程模型对比
+
+| SDK 层（bcos-sdk/sample） | Gateway 层（fisco-bcos-demo） |
+|--------------------------|-----------------------------|
+| `SdkFactory::buildSdk(config)` | `GatewayFactory::buildGateway(...)` |
+| `registerBlockNumberNotifier(group, cb)` | `registerHandlerByMsgType(999, cb)` |
+| `sendTransaction(...)` | `asyncSendMessage(msg)` |
+| `amop()->publish(...)` | 直接 P2P 消息 |
+| 回调含 Group、Error、bytes | 回调含 NetworkException、P2PSession、P2PMessage |
+
+---
+
+## 小结
+
+`echo_server_sample.cpp` 是 FISCO BCOS 中唯一直接操作 Gateway 层 P2P 接口的示例。78 行代码展示了极简的回显实现：**`registerHandlerByMsgType(999, cb)` 注册处理器 → `_msg->setRespPacket()` 标记响应 → `asyncSendMessage(_msg)` 原消息发回**。不需要消息工厂，不需要构建新消息对象。配置文件路径硬编码为 `"config.ini"`。

--- a/贡献内容/任务1-3-FISCO-BCOS样例代码总览.md
+++ b/贡献内容/任务1-3-FISCO-BCOS样例代码总览.md
@@ -1,0 +1,420 @@
+# FISCO BCOS 样例代码总览
+
+> 基于 FISCO BCOS v3.x 仓库中 `bcos-sdk/sample`、`fisco-bcos-demo`、`tools` 三个目录的样例代码，帮助新同学快速了解 SDK 能力，找到适合自己的学习入口。
+
+---
+
+## 目录结构总览
+
+```
+bcos-sdk/sample/
+├── amop/              # AMOP 消息通道（publish / subscribe / broadcast）
+├── config/            # SDK 配置文件模板（标准 / 国密）
+├── eventsub/          # 合约事件订阅
+├── rpc/               # RPC 调用（区块通知 / 压力测试）
+├── swig/              # Python SDK 快速入门
+├── tars/              # Tars RPC 性能查询
+└── tx/                # 交易操作（部署 / 压测 / 签名性能）
+
+fisco-bcos-demo/
+├── echo_server_sample.cpp   # P2P Echo 服务端
+├── echo_client_sample.cpp   # P2P Echo 客户端
+
+tools/
+├── BcosBuilder/       # 节点配置生成工具
+├── archive-tool/      # 数据归档工具
+├── storage-tool/      # 存储数据查看工具
+├── hsm-tool/          # 硬件安全模块工具
+├── kms-tool/          # 密钥管理工具
+└── template/          # 监控仪表盘模板
+```
+
+---
+
+## 一、bcos-sdk/sample — SDK 核心示例
+
+所有样例均遵循统一的三步初始化模式：`SdkFactory::buildSdk(config)` → `sdk->start()` → 调用具体功能 API。
+
+### 1.1 快速导航表
+
+| 文件 | 代码量 | 难度 | 一句话概括 | 源码链接 |
+|------|--------|------|-----------|----------|
+| `config/config_sample.ini` | 28行 | ★ | SDK 配置文件模板，含 SSL/节点/线程池参数 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/config/config_sample.ini) |
+| `rpc/blocknotifier.cpp` | 88行 | ★ | 监听区块高度变化，最简示例 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/rpc/blocknotifier.cpp) |
+| `tx/deploy_hello.cpp` | 298行 | ★★★ | **核心示例**：部署 HelloWorld 合约，覆盖配置读取→密钥生成→交易构建→回执解析全流程 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/tx/deploy_hello.cpp) |
+| `amop/publish.cpp` | 107行 | ★★ | AMOP 消息发布，等待订阅方响应 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/amop/publish.cpp) |
+| `amop/subscribe.cpp` | 101行 | ★★★ | AMOP 消息订阅，支持多 Topic，接收消息后 echo 回复 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/amop/subscribe.cpp) |
+| `amop/broadcast.cpp` | 81行 | ★★ | AMOP 广播（无回调单向推送） | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/amop/broadcast.cpp) |
+| `eventsub/eventsub.cpp` | 128行 | ★★★ | 按区块范围和合约地址过滤订阅事件日志 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/eventsub/eventsub.cpp) |
+| `rpc/rpc_test.cpp` | 203行 | ★★★★ | 100 线程极限 RPC 压测，手动构建 WsConfig（不使用 INI 文件） | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/rpc/rpc_test.cpp) |
+| `tx/hello_perf.cpp` | 280行 | ★★★★ | 含速率控制的合约调用压测工具 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/tx/hello_perf.cpp) |
+| `tx/tx_sign_perf.cpp` | 190行 | ★★ | ECDSA vs SM2 签名性能对比测试 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/tx/tx_sign_perf.cpp) |
+| `tx/random_perf.cpp` | 79行 | ★ | 随机数生成基准（纯计算，无网络 IO） | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/tx/random_perf.cpp) |
+| `swig/python_client.py` | 149行 | ★ | Python SDK 快速入门 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/swig/python_client.py) |
+| `tars/performanceQuery.cpp` | ~320行 | ★★★★★ | Tars 协议下 DAG 批量转账性能查询 | [查看](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/tars/performanceQuery.cpp) |
+
+### 1.2 各模块详解
+
+#### 配置文件：`config_sample.ini`
+
+```ini
+[common]
+    thread_pool_size = 8           # 网络 IO 线程池
+    message_timeout_ms = 10000     # 消息超时(ms)
+    send_rpc_request_to_highest_block_node = true
+
+[cert]
+    ssl_type = ssl                 # ssl 或 sm_ssl
+    ca_path = ./conf
+    ca_cert = ca.crt
+    sdk_key = sdk.key
+    sdk_cert = sdk.crt
+
+[peers]
+    node.0 = 127.0.0.1:20200
+    node.1 = 127.0.0.1:20201
+```
+
+所有样例共享这份配置，只需修改 `[peers]` 中的节点地址和 `[cert]` 中的证书路径即可。
+
+#### AMOP 消息通道
+
+AMOP（Advanced Message Online Protocol）是链上链下安全消息协议，支持三种通信模式：
+
+| 模式 | API | 是否等待响应 | 适用场景 |
+|------|-----|:---:|----------|
+| **发布-订阅** | `publish()` + `subscribe()` | 是 | 点对点可靠消息、命令下发 |
+| **广播** | `broadcast()` | 否 | 一对多通知公告、日志推送 |
+
+**publish 核心代码：**
+
+```cpp
+sdk->amop()->publish(
+    topic,                                          // 主题名
+    bytesConstRef((byte*)msg.data(), msg.size()),   // 消息体
+    -1,                                             // 超时(-1=无限等待)
+    [](Error::Ptr error, WsMessage::Ptr msg, ...) { // 异步回调
+        if (msg->status() == 0) {
+            // 收到订阅方响应
+            std::cout << string(msg->payload()->begin(), msg->payload()->end());
+        }
+    }
+);
+```
+
+**subscribe 双回调机制：**
+
+```cpp
+// 1. 设置全局消息处理器
+sdk->amop()->setSubCallback(
+    [&](Error::Ptr, const string& endPoint, const string& seq,
+        bytesConstRef data, ...) {
+        // 2. 将原消息 echo 回复给发布方
+        sdk->amop()->sendResponse(endPoint, seq, data);
+    }
+);
+// 3. 订阅 Topic（支持多 Topic）
+sdk->amop()->subscribe(topicList);
+```
+
+关键点：subscribe 必须先于 publish 启动；Topic 需完全匹配（区分大小写）；`publish()` 的 `-1` 超时表示永久等待响应。
+
+**broadcast vs publish：**
+
+```cpp
+// broadcast：无回调，纯单向推送
+sdk->amop()->broadcast(topic, bytesConstRef(...));
+
+// vs publish：有回调，等待响应
+sdk->amop()->publish(topic, ..., callback);
+```
+
+#### 事件订阅：`eventsub.cpp`
+
+支持按区块范围和合约地址过滤：
+
+```cpp
+auto params = std::make_shared<EventSubParams>();
+params->setFromBlock(from);    // -1 表示最新区块
+params->setToBlock(to);        // -1 表示最新区块
+if (!address.empty()) {
+    params->addAddress(address); // 可选：按合约地址过滤
+}
+
+sdk->eventSub()->subscribeEvent(
+    group, params,
+    [](Error::Ptr error, const string& events) {
+        // events 为 JSON 字符串，包含 blockNumber、address、topics、data 等
+    }
+);
+```
+
+用法示例：
+```bash
+./eventsub ./config_sample.ini group -1 -1              # 订阅所有事件
+./eventsub ./config_sample.ini group -1 -1 0xabc...     # 按合约地址过滤
+./eventsub ./config_sample.ini group 100 200            # 查询历史区间事件
+```
+
+#### RPC 调用：`blocknotifier.cpp` 与 `rpc_test.cpp`
+
+**blocknotifier（最简示例）：**
+
+```cpp
+auto sdk = factory->buildSdk(config);
+sdk->start();
+sdk->service()->registerBlockNumberNotifier(
+    group, [](const string& g, int64_t n) {
+        cout << "block: " << n << endl;
+    }
+);
+// 保持主线程运行
+while (true) { std::this_thread::sleep_for(10s); }
+```
+
+**rpc_test（高级压测）：**
+
+不使用 INI 文件，纯代码构建 `WsConfig`，然后创建 100 个线程持续创建/销毁 SDK 实例并发调用 `getBlockNumber()`。这是极限压力测试，不适合生产环境参考。
+
+```bash
+./rpc 127.0.0.1 20200 ssl group0       # 标准 SSL
+./rpc 127.0.0.1 20200 sm_ssl group0    # 国密 SSL
+```
+
+#### 交易操作：`tx/` 目录
+
+**deploy_hello — 最完整的合约部署流程（298行）：**
+
+```
+配置读取 → 群组信息查询 → 密钥对生成(SM2/ECDSA) → BlockLimit获取
+→ 字节码准备(标准/国密) → sendTransaction → 异步回调解析回执 → 提取合约地址
+```
+
+关键代码片段：
+
+```cpp
+// 根据群组密码类型选择算法和字节码
+if (groupInfo->smCryptoType()) {
+    keyPairFactory = make_shared<SM2Crypto>();     // 国密 SM2
+    hexBin = hwSmBIN;                              // 国密版字节码
+} else {
+    keyPairFactory = make_shared<Secp256k1Crypto>(); // 标准 ECDSA
+    hexBin = hwBIN;                                 // 标准版字节码
+}
+
+// 发送部署交易
+rpcService->sendTransaction(
+    *keyPair, group, "", "",          // 部署时 to="" data=""
+    move(*binBytes),                  // 合约字节码
+    "", 0, "extraData",
+    [&](Error::Ptr e, shared_ptr<bytes> resp) {
+        Json::Value root;
+        reader.parse(string(resp->begin(), resp->end()), root);
+        string addr = root["result"]["contractAddress"].asString();
+    }
+);
+```
+
+用法：`./deploy_hello ./config_sample.ini group0`
+
+**hello_perf — 含速率控制的压测工具：**
+
+先部署合约，再用 `TimeWindowRateLimiter` 控制 QPS，通过 `RateReporter` 统计 TPS，多线程持续调用合约方法。
+
+用法：`./hello_perf ./config_sample.ini group0 16 1024`（16并发 / 1024 QPS）
+
+**tx_sign_perf — 签名性能对比：**
+
+```bash
+./tx_sign_perf false 30000    # ECDSA 签名 30000 次
+./tx_sign_perf true 30000     # SM2 签名 30000 次
+```
+
+**random_perf — 纯计算基准：**
+
+无网络 IO，纯粹测试随机数生成性能，用于建立性能基线。
+
+#### 跨语言：`swig/` 和 `tars/`
+
+- **python_client.py**：通过 SWIG 绑定，提供 Python 调用 SDK 的快速入门示例
+- **tars/performanceQuery.cpp**：基于腾讯 Tars RPC 框架的批量 DAG 转账性能查询，涉及 TBB 并行计算，是最高难度的示例
+
+---
+
+## 二、fisco-bcos-demo — P2P 网络层演示
+
+不同于 SDK 层的 RPC/AMOP 接口，这两个示例直接使用 Gateway 层的 P2P 接口，展示节点间最底层的网络通信。
+
+### echo_server_sample.cpp（78行）
+
+通过 `GatewayFactory` 构建 P2P Gateway，注册自定义消息类型（999 = Echo 测试），收到消息后原路返回：
+
+```cpp
+GatewayFactory gatewayFactory(nodeConfig->chainId(), "localClient", nullptr);
+auto gateway = gatewayFactory.buildGateway(configFilePath, true, nullptr, "localClient");
+auto service = dynamic_pointer_cast<Service>(gateway->p2pInterface());
+gateway->start();
+
+service->registerHandlerByMsgType(999,
+    [](NetworkException e, P2PSession::Ptr session, P2PMessage::Ptr msg) {
+        if (e.errorCode()) return;
+        msg->setRespPacket();
+        session->session()->asyncSendMessage(msg);
+    }
+);
+```
+
+### echo_client_sample.cpp（111行）
+
+使用 `RateLimiter` 控制发包速率，向指定节点发送自定义消息类型的 P2P 数据包，统计往返延迟（RTT）：
+
+```bash
+./echo-client-sample 10 127.0.0.1 30303 1024
+# 参数: QPS(Mbps) 服务端地址 端口 载荷(KB)
+```
+
+输出示例：
+
+```
+### payLoad:1048576  ### packetQPS: 10
+receiveResponse, timecost:15, msgSize:1048576
+receiveResponse, timecost:16, msgSize:1048576
+```
+
+### Echo Demo 与 SDK 的关系
+
+| 层面 | SDK 示例（bcos-sdk/sample） | Echo 示例（fisco-bcos-demo） |
+|------|---------------------------|----------------------------|
+| 通信层级 | RPC / AMOP（应用层协议） | P2P Session（传输层协议） |
+| 初始化方式 | `SdkFactory::buildSdk(config.ini)` | `GatewayFactory::buildGateway(config.ini)` |
+| 适用场景 | 交易、合约调用、事件订阅 | 自定义 P2P 协议开发、网络性能测试 |
+| 难度 | ★ ~ ★★★★ | ★★ |
+
+---
+
+## 三、tools — 运维辅助工具
+
+tools 目录提供节点运维、数据管理和安全相关的辅助工具。
+
+| 工具 | 主要文件 | 用途说明 |
+|------|---------|----------|
+| **BcosBuilder** | `src/common/utilities.py` | Python 脚本，用于生成节点配置文件（genesis、config.ini、tars 配置），含配置模板 |
+| **archive-tool** | `archiveTool.cpp` | 区块链历史数据归档服务，将旧区块数据从活跃存储迁移到归档存储 |
+| **storage-tool** | `storageTool.cpp` / `reader.cpp` | 直接读取 RocksDB/TiKV 底层存储数据，用于调试和数据巡检 |
+| **hsm-tool** | `encryptCertFile.cpp` | 与硬件安全模块（HSM）集成，对证书文件进行加密处理 |
+| **kms-tool** | `KmsTool.cpp` | 对接密钥管理系统（KMS），管理节点的签名密钥 |
+| **template** | `Dashboard.json` | Grafana 仪表盘模板，用于监控节点运行状态 |
+
+### BcosBuilder 配置生成
+
+BcosBuilder 读取 Python 配置文件，自动生成：
+- `config.genesis` — 创世块配置（共识节点列表、群组配置）
+- `config.ini.node` — 节点配置文件模板
+- `config.ini.rpc` — RPC 服务配置模板
+- `tars_node.conf` / `tars_rpc.conf` — Tars 服务配置
+
+这是搭建 FISCO BCOS 网络的第一步工具。
+
+### storage-tool 数据巡检
+
+直接读取节点存储层（RocksDB）的数据，用于：
+- 查看指定区块的交易列表
+- 检查合约状态存储
+- 验证数据完整性
+- 调试存储层异常
+
+这些工具适合运维和深入排查问题时使用，与开发层面的 SDK 示例互补。
+
+---
+
+## 四、推荐学习路径
+
+针对不同背景的新同学，推荐以下入口：
+
+### 路径 A：初次接触区块链开发
+
+```
+Step 1: config_sample.ini        理解 SDK 如何连接节点
+Step 2: blocknotifier.cpp        体验"连接→回调→后台运行"的最简模式
+Step 3: deploy_hello.cpp         掌握合约部署全流程（最重要）
+Step 4: publish.cpp + subscribe.cpp  理解链上链下消息通信
+```
+
+### 路径 B：有以太坊/web3 经验的开发者
+
+```
+Step 1: deploy_hello.cpp         对比 sendTransaction 与 web3 的差异
+Step 2: eventsub.cpp             理解事件过滤机制（from/to/address）
+Step 3: hello_perf.cpp           压测工具，评估网络吞吐上限
+Step 4: rpc_test.cpp             手动构建 WsConfig，绕过 INI 配置
+Step 5: python_client.py         快速用 Python 原型验证
+```
+
+### 路径 C：区块链运维 / DevOps
+
+```
+Step 1: tools/BcosBuilder/       搭建测试网络
+Step 2: blocknotifier.cpp        开发区块监控、告警
+Step 3: tools/storage-tool/      掌握节点底层数据巡检
+Step 4: echo_server_sample.cpp   理解 P2P 网络层，用于网络故障诊断
+Step 5: tools/template/          部署 Grafana 监控面板
+```
+
+### 路径 D：性能测试与调优
+
+```
+Step 1: random_perf.cpp          建立纯计算性能基线
+Step 2: tx_sign_perf.cpp         评估密码学开销（SM2 vs ECDSA）
+Step 3: hello_perf.cpp           合约调用吞吐压测
+Step 4: echo_client_sample.cpp   网络层 RTT 延迟测量
+Step 5: rpc_test.cpp             极限并发稳定性测试
+```
+
+---
+
+## 五、所有命令速查
+
+| 操作 | 命令 |
+|------|------|
+| 部署 HelloWorld | `./deploy_hello ./config_sample.ini group0` |
+| 监控区块高度 | `./blocknotifier ./config_sample.ini group` |
+| AMOP 发布消息 | `./publish ./config_sample.ini topic HelloWorld` |
+| AMOP 订阅消息 | `./subscribe ./config_sample.ini topic` |
+| AMOP 广播消息 | `./broadcast ./config_sample.ini topic HelloWorld` |
+| 事件订阅 | `./eventsub ./config_sample.ini group -1 -1` |
+| RPC 压力测试 | `./rpc 127.0.0.1 20200 ssl group0` |
+| HelloWorld 压测 | `./hello_perf ./config_sample.ini group0 16 1024` |
+| 签名性能测试 | `./tx_sign_perf true 30000` |
+| 随机数基准测试 | `./random_perf 30000` |
+| Echo 客户端 | `./echo-client-sample 10 127.0.0.1 30303 1024` |
+
+---
+
+## 附录：核心 API 速查
+
+| API | 所属模块 | 用途 |
+|-----|---------|------|
+| `SdkFactory::buildSdk(config)` | SDK 初始化 | 从 INI 文件构建 SDK |
+| `Sdk::start()` | SDK 初始化 | 启动 WebSocket 连接 |
+| `Service::registerBlockNumberNotifier()` | RPC | 注册区块高度回调 |
+| `Service::getGroupInfo(group)` | RPC | 查询群组信息（含国密类型） |
+| `Service::getBlockLimit()` | RPC | 获取交易有效期 |
+| `JsonRpcService::sendTransaction()` | RPC | 发送交易（部署/调用） |
+| `AMOP::publish(topic, data, timeout, cb)` | AMOP | 发布消息，等待响应 |
+| `AMOP::subscribe(topicList)` | AMOP | 订阅 Topic 列表 |
+| `AMOP::broadcast(topic, data)` | AMOP | 广播消息（无响应） |
+| `AMOP::setSubCallback(cb)` | AMOP | 设置消息接收回调 |
+| `AMOP::sendResponse(endPoint, seq, data)` | AMOP | 向发布方发送回复 |
+| `EventSub::subscribeEvent(group, params, cb)` | 事件 | 订阅合约事件 |
+| `GatewayFactory::buildGateway()` | P2P | 构建 P2P Gateway |
+| `Service::registerHandlerByMsgType()` | P2P | 注册自定义消息处理器 |
+| `Service::asyncSendMessageByEndPoint()` | P2P | 向指定节点发送 P2P 消息 |
+
+---
+
+## 相关资源
+
+- FISCO BCOS 源码仓库：[https://github.com/FISCO-BCOS/FISCO-BCOS](https://github.com/FISCO-BCOS/FISCO-BCOS)
+- 官方技术文档：[https://fisco-bcos-documentation.readthedocs.io/](https://fisco-bcos-documentation.readthedocs.io/)
+- Java SDK：[https://github.com/FISCO-BCOS/java-sdk](https://github.com/FISCO-BCOS/java-sdk)
+- Python SDK：[https://github.com/FISCO-BCOS/python-sdk](https://github.com/FISCO-BCOS/python-sdk)

--- a/贡献内容/任务1-4-HelloWorld合约部署源码走读.md
+++ b/贡献内容/任务1-4-HelloWorld合约部署源码走读.md
@@ -1,0 +1,208 @@
+# HelloWorld 合约部署源码走读
+
+> **源码文件**: [deploy_hello.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/tx/deploy_hello.cpp)
+> **代码行数**: 298行
+> **核心功能**: 通过 SDK 部署 HelloWorld 合约到区块链，覆盖完整的交易生命周期
+
+---
+
+## 任务目标
+
+讲清四个核心流程：**配置读取 → 群组信息获取(含密码类型判断) → 账户(密钥对)生成 → 合约部署交易发送与回执解析**。
+
+---
+
+## 一、源码结构总览（按行号分段）
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-30 | 头文件引入 |
+| 36-116 | HelloWorld 合约源码 + 两套字节码常量 |
+| 120-123 | `getBinary(sm)` 辅助函数 |
+| 125-133 | `usage()` 帮助信息 |
+| 135-153 | **SDK 初始化** |
+| 156-176 | **群组信息获取 + 密钥对生成** |
+| 184-236 | **getBlockLimit + 字节码选择 + sendTransaction + 回执解析 + f.get()** |
+| 237-295 | 注释掉的备选实现（TransactionBuilderService 版本） |
+
+---
+
+## 二、分步走读
+
+### 第1步：SDK 初始化（行148-153）
+
+```cpp
+auto factory = std::make_shared<SdkFactory>();
+auto sdk = factory->buildSdk(config);   // config 是 argv[1]，直接传字符串路径
+sdk->start();
+```
+
+`buildSdk()` 接收配置文件路径字符串，内部完成 INI 解析、证书加载、节点连接。不需要额外的 `SampleConfig` 包装。
+
+### 第2步：获取群组信息（行156-163）
+
+```cpp
+bcos::group::GroupInfo::Ptr groupInfo = sdk->service()->getGroupInfo(group);
+if (!groupInfo) {
+    std::cout << "group not exist" << std::endl;
+    exit(-1);
+}
+```
+
+`GroupInfo` 对象携带群组链信息。最关键的是 `smCryptoType()` 字段——它决定所有密码学操作走国密 SM2 还是标准 ECDSA。
+
+### 第3步：生成密钥对（行165-176）
+
+```cpp
+crypto::SignatureCrypto::Ptr keyPairFactory;
+crypto::KeyPairInterface::UniquePtr keyPair;
+
+if (groupInfo->smCryptoType()) {
+    keyPairFactory = std::make_shared<bcos::crypto::SM2Crypto>();
+    keyPair = keyPairFactory->generateKeyPair();
+} else {
+    keyPairFactory = std::make_shared<bcos::crypto::Secp256k1Crypto>();
+    keyPair = keyPairFactory->generateKeyPair();
+}
+```
+
+关键设计：**密钥对类型必须与群组密码类型匹配**。注意这里分两个阶段——先创建 `SignatureCrypto` 工厂，再调用 `generateKeyPair()` 生成 `KeyPairInterface::UniquePtr`。
+
+### 第4步：获取 BlockLimit（行184-185）
+
+```cpp
+int64_t blockLimit = -1;
+sdk->service()->getBlockLimit(group, blockLimit);   // 输出参数模式
+```
+
+`getBlockLimit` 采用输出参数模式（传入引用），不是返回值。`-1` 是初始值，调用后被更新为当前区块号 + 上限（通常约 1000）。
+
+### 第5步：选择合约字节码（行120-123 + 190-191）
+
+HelloWorld 有两套预编译字节码：
+- `hwBIN`（行56-79）：ECDSA 标准版
+- `hwSmBIN`（行81-104）：国密 SM 版
+
+```cpp
+auto hexBin = getBinary(groupInfo->smCryptoType());  // 根据国密标志选版本
+auto binBytes = fromHexString(std::string(hexBin));    // hex → bytes
+```
+
+### 第6步（核心）：sendTransaction 部署调用（行193-234）
+
+```cpp
+auto rpcService = sdk->jsonRpcService();
+
+std::promise<bool> p;
+auto f = p.get_future();
+
+rpcService->sendTransaction(
+    *keyPair,                    // 1. 签名密钥对
+    group,                       // 2. 群组ID
+    "",                          // 3. to: 部署合约时为空
+    "",                          // 4. data: 构造函数参数，空
+    std::move(*binBytes),        // 5. 合约字节码（move 转移所有权）
+    "",                          // 6. ABI，部署时不填
+    0,                           // 7. 属性值
+    "extraData",                 // 8. 附加数据
+    // ===== 异步回调 =====
+    [&p](bcos::Error::Ptr _error, std::shared_ptr<bcos::bytes> _resp) {
+        if (_error && _error->errorCode() != 0) {
+            std::cout << "deploy failed: " << _error->errorCode() << ":"
+                      << _error->errorMessage() << std::endl;
+        } else {
+            std::string receipt(_resp->begin(), _resp->end());
+            // 解析 JSON 回执
+            Json::Value root;
+            Json::Reader jsonReader;
+            if (jsonReader.parse(receipt, root)) {
+                std::cout << "contract address ==> "
+                          << root["result"]["contractAddress"].asString() << std::endl;
+            }
+        }
+        p.set_value(true);
+    }
+);
+
+f.get();  // 阻塞等待异步结果
+```
+
+**参数说明**：
+
+| 参数 | 值 | 含义 |
+|------|-----|------|
+| `*keyPair` | 解引用 `UniquePtr` | 签名密钥对 |
+| `""` (to) | 空字符串 | 表示**合约部署**（非调用） |
+| `""` (data) | 空字符串 | 构造函数参数，HelloWorld 无参 |
+| `std::move(*binBytes)` | 移动 | 字节码所有权转移，避免大对象拷贝 |
+
+**异步同步化**：`std::promise/future` 将异步回调转为同步等待。`f.get()` 阻塞直到 `p.set_value(true)` 被调用。
+
+### 第7步：回执 JSON 结构
+
+```json
+{
+  "result": {
+    "contractAddress": "0x..."
+  }
+}
+```
+
+回调中直接通过 `root["result"]["contractAddress"].asString()` 提取合约地址。
+
+---
+
+## 三、运行方法
+
+```bash
+./deploy_hello ./config_sample.ini group0
+```
+
+| 参数 | 说明 |
+|------|------|
+| `./config_sample.ini` | SDK 配置文件路径 |
+| `group0` | 目标群组 ID |
+
+---
+
+## 四、完整流程图
+
+```
+argv[1] (配置路径字符串)
+      ↓
+SdkFactory::buildSdk(config)  → sdk->start()
+      ↓
+getGroupInfo("group0")  ──→  smCryptoType()?
+      ↓                         ↓ 是              ↓ 否
+SM2Crypto                Secp256k1Crypto
+  generateKeyPair()        generateKeyPair()
+      ↓                         ↓
+getBinary(true)→hwSmBIN   getBinary(false)→hwBIN
+      ↓                         ↓
+getBlockLimit(group, blockLimit)  ← 输出参数
+      ↓
+jsonRpcService()->sendTransaction(
+    *keyPair, group, "", "", std::move(*binBytes), "", 0, "extraData", callback)
+      ↓ 异步
+f.get() 阻塞等待 → callback: JSON解析 → contractAddress
+```
+
+---
+
+## 五、关键 API 速查
+
+| API | 作用 | 所在行 |
+|-----|------|--------|
+| `SdkFactory::buildSdk(configPath)` | 从字符串路径创建 SDK | 150 |
+| `Service::getGroupInfo(group)` | 获取群组信息（含国密标识） | 157 |
+| `Service::getBlockLimit(group, blockLimit)` | 获取交易有效期（输出参数） | 185 |
+| `SM2Crypto::generateKeyPair()` | 生成国密密钥对 | 170 |
+| `Secp256k1Crypto::generateKeyPair()` | 生成 ECDSA 密钥对 | 174 |
+| `Sdk::jsonRpcService()` | 获取 JSON-RPC 服务 | 193 |
+| `jsonRpcService->sendTransaction(...)` | 发送部署交易 | 197 |
+
+---
+
+## 小结
+
+`deploy_hello.cpp` 是 FISCO BCOS SDK 中最完整的入门示例，298 行代码串联了**字符串配置 → 群组连接 → 密码学适配（SM2Crypto / Secp256k1Crypto）→ 字节码选择 → 交易发送 → promise/future 异步同步化 → 回执解析**全链路。理解这个文件后，合约调用只需把 `to` 地址从空改为目标合约地址即可。

--- a/贡献内容/任务1-5-区块高度通知样例源码走读.md
+++ b/贡献内容/任务1-5-区块高度通知样例源码走读.md
@@ -1,0 +1,132 @@
+# 区块高度通知样例源码走读
+
+> **源码文件**: [blocknotifier.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/rpc/blocknotifier.cpp)
+> **代码行数**: 88行
+> **核心功能**: 注册区块高度回调，实时打印新区块号
+
+---
+
+## 任务目标
+
+讲清两个核心概念：**`registerBlockNumberNotifier` 的注册机制**和**回调函数的执行流程**。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-39 | 头文件引入 + namespace |
+| 43-51 | `usage()` 帮助信息 |
+| 54-72 | **SDK 初始化** |
+| 75-79 | **核心：registerBlockNumberNotifier 注册回调** |
+| 81-85 | 主循环保持进程不退出 |
+
+---
+
+## 二、分步走读
+
+### 第1步：SDK 初始化（行67-72）
+
+```cpp
+auto factory = std::make_shared<SdkFactory>();
+auto sdk = factory->buildSdk(config);   // config = argv[1]，字符串路径
+sdk->start();
+```
+
+`buildSdk()` 接收配置文件的字符串路径，内部完成 INI 解析、证书加载、节点连接。
+
+### 第2步（核心）：注册区块高度通知器（行75-79）
+
+```cpp
+sdk->service()->registerBlockNumberNotifier(
+    group,                                              // 群组ID (argv[2])
+    [](const std::string& _group, int64_t _blockNumber) {
+        std::cout << "block notifier ===>>>> "
+                  << "group: " << _group
+                  << ", blockNumber: " << _blockNumber
+                  << std::endl;
+    }
+);
+```
+
+**回调参数**：
+
+| 参数 | 类型 | 含义 |
+|------|------|------|
+| `_group` | `const std::string&` | 群组 ID 字符串，如 `"group0"` |
+| `_blockNumber` | `int64_t` | 新区块编号 |
+
+**回调执行时机**：每当链上产生新区块，SDK 内部触发此回调。回调在 SDK 线程池中异步执行，不阻塞区块同步。
+
+### 第3步：主线程保活（行81-85）
+
+```cpp
+while (true) {
+    std::cout << "Main thread running" << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10000));
+}
+```
+
+SDK 的所有网络 IO 和回调都在后台线程执行，主线程必须保持存活。这里用 `sleep` 循环消耗极低 CPU，每 10 秒打印一行心跳。
+
+---
+
+## 三、运行方法
+
+```bash
+./blocknotifier ./config_sample.ini group0
+```
+
+| 参数 | 说明 |
+|------|------|
+| `./config_sample.ini` | SDK 配置文件路径 |
+| `group0` | 要监听的群组 ID |
+
+输出示例：
+
+```
+[BlockNotifier] start sdk ...
+block notifier ===>>>> group: group0, blockNumber: 105
+Main thread running
+block notifier ===>>>> group: group0, blockNumber: 106
+Main thread running
+...
+```
+
+---
+
+## 四、回调注册流程图
+
+```
+main()
+  ↓
+SdkFactory::buildSdk(config)      // 传入字符串路径
+  ↓
+sdk->start()                      // 启动 WebSocket 连接
+  ↓
+registerBlockNumberNotifier(group, lambda)
+  │                                    ↓
+  │                    注册回调到 SDK 内部通知器列表
+  │                                    ↓
+  ↓ 返回                          SDK 后台线程监听新区块
+  ↓                                    ↓
+while(true) sleep(10s)          新区块产生 → 触发 lambda
+                                      ↓
+                                 打印 group + blockNumber
+```
+
+---
+
+## 五、关键 API
+
+| API | 作用 |
+|-----|------|
+| `SdkFactory::buildSdk(configPath)` | 从字符串路径创建 SDK |
+| `Service::registerBlockNumberNotifier(group, callback)` | 注册区块高度变化回调 |
+
+---
+
+## 小结
+
+`blocknotifier.cpp` 是 SDK 中最简单的示例（88行），完整展示 **SdkFactory 初始化 → 回调注册 → 异步响应** 的标准模式。回调参数是简单的 `(string, int64_t)` 对，每次新区块打印群组和高度。这是构建区块监控、告警系统的最基础组件。

--- a/贡献内容/任务1-6-事件订阅样例源码走读.md
+++ b/贡献内容/任务1-6-事件订阅样例源码走读.md
@@ -1,0 +1,192 @@
+# 事件订阅样例源码走读
+
+> **源码文件**: [eventsub.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/eventsub/eventsub.cpp)
+> **代码行数**: 128行
+> **核心功能**: 订阅区块链合约事件日志，支持按区块范围和合约地址过滤
+
+---
+
+## 任务目标
+
+讲清三个核心参数的用法和含义：**`from` / `to`（区块范围）**、**`address`（合约地址过滤）**，以及事件回调的处理逻辑。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-39 | 头文件引入 + namespace |
+| 42-51 | `usage()` 帮助信息 |
+| 53-91 | 参数解析 + SDK初始化 + EventSubParams 配置 |
+| 93-98 | **先注册区块高度通知器** |
+| 100-119 | **核心：subscribeEvent 订阅事件** |
+| 121-127 | 主循环保活 |
+
+---
+
+## 二、分步走读
+
+### 第1步：命令行参数解析（行53-70）
+
+```cpp
+// argv[1]: config_path    — 配置文件路径
+// argv[2]: group          — 群组ID
+// argv[3]: from           — 起始区块号
+// argv[4]: to             — 结束区块号
+// argv[5]: address (可选) — 合约地址过滤
+
+int64_t from = atoi(argv[3]);
+int64_t to = atoi(argv[4]);
+
+std::string address;
+if (argc > 5) {
+    address = argv[5];
+}
+```
+
+**from/to 的三种语义**：
+
+| 值 | 含义 |
+|---|------|
+| `-1` | 表示最新区块（实时订阅） |
+| 正数 N | 指定区块号 N |
+| `from=100, to=200` | 查询历史区间 [100, 200] |
+
+**address 参数**：
+- 不传：订阅全链所有合约事件
+- 传入 `0x...`：仅订阅该合约地址产生的事件
+
+### 第2步：构建 EventSubParams（行85-91）
+
+```cpp
+auto params = std::make_shared<bcos::cppsdk::event::EventSubParams>();
+params->setFromBlock(from);
+params->setToBlock(to);
+if (!address.empty()) {
+    params->addAddress(address);
+}
+```
+
+`EventSubParams` 核心方法：
+
+| 方法 | 说明 |
+|------|------|
+| `setFromBlock(int64_t)` | 设置起始区块，-1 为最新 |
+| `setToBlock(int64_t)` | 设置结束区块，-1 为最新 |
+| `addAddress(string)` | 按合约地址过滤事件（可多次调用） |
+
+### 第3步：区块高度通知器（行93-98）
+
+```cpp
+sdk->service()->registerBlockNumberNotifier(
+    group,
+    [](const std::string& _group, int64_t _blockNumber) {
+        std::cout << "recv block number notifier ===>>>> "
+                  << "group: " << _group
+                  << ", blockNumber: " << _blockNumber << std::endl;
+    }
+);
+```
+
+**先注册区块通知器，再注册事件订阅**。双监听器模式很常用：区块通知确认链正常运行，事件通知聚焦业务数据。
+
+### 第4步（核心）：subscribeEvent 订阅（行100-119）
+
+```cpp
+sdk->eventSub()->subscribeEvent(
+    group,                                               // 群组ID
+    params,                                              // 过滤参数
+    [](Error::Ptr _error, const std::string& _events) {  // 回调：2个参数
+        if (_error) {
+            std::cout << "something is wrong"
+                      << " code: " << _error->errorCode()
+                      << " message: " << _error->errorMessage() << std::endl;
+            std::exit(-1);                               // 错误时直接退出
+        } else {
+            // ★ 直接打印 **原始 JSON 字符串**
+            std::cout << "recv events ===>>>> "
+                      << "events: " << _events << std::endl;
+        }
+    }
+);
+```
+
+**回调参数**：
+
+| 参数 | 类型 | 含义 |
+|------|------|------|
+| `_error` | `Error::Ptr` | 错误对象，null 表示成功；有错误时直接 `exit(-1)` |
+| `_events` | `const std::string&` | 事件日志的 **原始 JSON 字符串** |
+
+源码中回调**不做任何 JSON 解析**，直接打印 `_events` 字符串。实际应用中可以解析它获取 `blockNumber`、`address`、`data`、`topics` 等字段。
+
+---
+
+## 三、运行方法
+
+```bash
+# 实时订阅全链所有事件
+./eventsub ./config_sample.ini group0 -1 -1
+
+# 实时订阅指定合约的事件
+./eventsub ./config_sample.ini group0 -1 -1 0xabc123...
+
+# 查询历史区间事件
+./eventsub ./config_sample.ini group0 100 200
+```
+
+**参数说明**：
+
+| 参数索引 | 名称 | 说明 |
+|---------|------|------|
+| 1 | config_path | INI 配置文件路径 |
+| 2 | group | 群组 ID |
+| 3 | from | 起始区块号，`-1` 表示最新 |
+| 4 | to | 结束区块号，`-1` 表示最新 |
+| 5 | address (可选) | 合约地址 |
+
+---
+
+## 四、事件过滤流程图
+
+```
+命令行参数
+  ↓
+atoi(argv[3]), atoi(argv[4])   → from, to
+  ↓
+EventSubParams
+  ├── setFromBlock(-1)    ← from
+  ├── setToBlock(-1)      ← to
+  └── addAddress(0x...)   ← address (可选)
+  ↓
+① registerBlockNumberNotifier(group, cb)    ← 先注册区块通知
+  ↓
+② subscribeEvent(group, params, cb)         ← 再注册事件订阅
+  │                            ↓
+  ↓ 返回                  SDK 后台匹配事件
+  │                            ↓
+while(true) sleep(10s)   匹配到 → cb(_error, _events)
+                               ↓
+                          _error ? → exit(-1)
+                               ↓
+                          打印 _events 原始 JSON
+```
+
+---
+
+## 五、关键 API
+
+| API | 作用 |
+|-----|------|
+| `EventSubParams::setFromBlock(n)` | 设置起始区块，-1 为最新 |
+| `EventSubParams::setToBlock(n)` | 设置结束区块，-1 为最新 |
+| `EventSubParams::addAddress(addr)` | 按合约地址过滤 |
+| `Sdk::eventSub()->subscribeEvent(group, params, cb)` | 注册事件订阅 |
+| `Sdk::service()->registerBlockNumberNotifier(group, cb)` | 区块高度通知（辅助） |
+
+---
+
+## 小结
+
+`eventsub.cpp` 通过 128 行代码演示了灵活的事件过滤机制：**from/to=-1 实现实时订阅**，**from/to=具体数字实现历史查询**，**address 参数实现合约级过滤**。回调接收原始 JSON 字符串 `_events`，实际使用时需自行解析。注意源码中先注册 `blockNumberNotifier` 再注册 `subscribeEvent`，且回调遇到错误时直接 `exit(-1)` 终止程序。

--- a/贡献内容/任务1-7-RPC调用发起流程教程.md
+++ b/贡献内容/任务1-7-RPC调用发起流程教程.md
@@ -1,0 +1,213 @@
+# 一次 RPC 调用是如何发起的
+
+> **源码文件**: [rpc_test.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/rpc/rpc_test.cpp)
+> **代码行数**: 203行
+> **核心功能**: 手动构建 WsConfig 并发起 RPC 调用，100 线程极限压测 `getBlockNumber`
+
+---
+
+## 任务目标
+
+讲清三个核心环节：**命令行参数解析 → WsConfig 手动初始化 → `getBlockNumber` 调用的完整链路**。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-31 | 头文件引入 |
+| 33-41 | `usage()` |
+| 42-73 | C 结构体定义（bcos_sdk_c_endpoint / cert_config / config） |
+| 74-108 | **核心：`initWsConfig()` 手动构建 WsConfig** |
+| 109-124 | `thread_function()` 线程压测逻辑 |
+| 126-158 | `bcos_sdk_create_config()` 工厂函数 |
+| 159-203 | **main()：命令行解析 → 100 线程启动** |
+
+---
+
+## 二、分步走读
+
+### 第1步：命令行参数解析（行159-180）
+
+```cpp
+// ./rpc 127.0.0.1 20200 ssl group0      (标准 SSL)
+// ./rpc 127.0.0.1 20200 sm_ssl group0   (国密 SSL)
+
+const char* host = argv[1];    // 节点 IP
+int port = atoi(argv[2]);      // 端口
+const char* type = argv[3];    // "ssl" 或 "sm_ssl"
+const char* group = argv[4];   // 群组ID
+
+int is_sm_ssl = (strstr(type, "sm_ssl") != NULL) ? 1 : 0;
+```
+
+与 `deploy_hello` 等通过 INI 文件配置不同，本示例**不使用配置文件**，所有连接信息均通过命令行传入。`strstr` 用于检测参数中是否包含 `"sm_ssl"` 子串。
+
+### 第2步：C 结构体工厂函数（行126-158）
+
+```cpp
+auto config = bcos_sdk_create_config(is_sm_ssl, host, port);
+
+// 内部实现:
+auto config = std::make_shared<bcos_sdk_c_config>();
+config->thread_pool_size = 8;              // 8 线程池
+config->message_timeout_ms = 10000;         // 10秒超时
+config->disable_ssl = 1;                    // ★ 跳过 SSL 校验（压测优化）
+config->send_rpc_request_to_highest_block_node = 1;
+config->ssl_type = sm_ssl ? "sm_ssl" : "ssl";
+config->is_cert_path = 1;
+config->cert_config = {
+    .ca_cert = "./conf/ca.crt",
+    .node_key = "./conf/sdk.key",
+    .node_cert = "./conf/sdk.crt"};
+
+// 设置对端节点
+bcos_sdk_c_endpoint ep = {host, port};
+config->peers.push_back(ep);
+config->peers_count = 1;
+```
+
+关键点：`disable_ssl = 1`。压测场景下每个线程创建独立 SDK 实例，跳过证书验证减少开销。**生产环境不应设为 1**。
+
+### 第3步：WsConfig 构建（行74-108）
+
+```cpp
+static std::shared_ptr<WsConfig> initWsConfig(
+    std::shared_ptr<bcos_sdk_c_config> config)
+{
+    auto wsConfig = std::make_shared<WsConfig>();
+    wsConfig->setModel(WsModel::Client);
+
+    // 1. 设置对端节点列表
+    auto peers = std::make_shared<EndPoints>();
+    for (size_t i = 0; i < config->peers_count; i++) {
+        peers->insert(NodeIPEndpoint(config->peers[i].host, config->peers[i].port));
+    }
+    wsConfig->setConnectPeers(peers);
+
+    // 2. 基础参数
+    wsConfig->setDisableSsl(config->disable_ssl);
+    wsConfig->setThreadPoolSize(config->thread_pool_size);
+    wsConfig->setReconnectPeriod(config->reconnect_period_ms);
+    wsConfig->setHeartbeatPeriod(config->heartbeat_period_ms);
+    wsConfig->setSendMsgTimeout(config->message_timeout_ms);
+
+    // 3. SSL 证书配置（仅在 enable_ssl 时）
+    if (!config->disable_ssl) {
+        auto contextConfig = std::make_shared<ContextConfig>();
+        contextConfig->setSslType(config->ssl_type);
+        contextConfig->setIsCertPath(config->is_cert_path);
+        // ... 设置 certConfig
+        wsConfig->setContextConfig(contextConfig);
+    }
+    return wsConfig;
+}
+```
+
+关键差异：使用 `setConnectPeers(EndPoints)` 而非 `addConnectedNode()`，且通过 `setDisableSsl/ setReconnectPeriod / setHeartbeatPeriod` 等精细控制。
+
+### 第4步：thread_function 并发模式（行109-124）
+
+```cpp
+void* thread_function(std::shared_ptr<bcos_sdk_c_config> arg)
+{
+    while (1) {
+        auto factory = std::make_shared<SdkFactory>();
+        auto wsConfig = initWsConfig(arg);
+        auto sdk = factory->buildSdk(wsConfig, arg->send_rpc_request_to_highest_block_node);
+        sdk->start();
+
+        auto rpc = sdk->jsonRpc();
+        rpc->getBlockNumber(
+            "group0", "",    // 群组ID + 空参数
+            [](Error::Ptr error, std::shared_ptr<bcos::bytes> resp) {}  // 空回调
+        );
+
+        usleep(100);
+        sdk->stop();
+        sdk.reset(nullptr);
+    }
+}
+```
+
+**关键模式**：
+1. 每次循环**创建独立 SDK 实例**——测试每次新建连接的开销
+2. 通过 `sdk->jsonRpc()` 获取 JSON-RPC 接口
+3. 调用 `getBlockNumber("group0", "", callback)` —— **不是 `callRemoteMethod`**
+4. 回调为空 lambda（压测不需要处理结果）
+5. `sdk->stop()` + `sdk.reset(nullptr)` 彻底销毁
+
+### 第5步：100 线程启动（行184-201）
+
+```cpp
+std::thread threads[100];
+for (long t = 0; t < 100; t++) {
+    threads[t] = std::thread(thread_function, config);  // 共享同一个 config
+}
+for (long t = 0; t < 100; t++) {
+    threads[t].join();
+}
+```
+
+100 个线程共享同一个 `config` 对象（`shared_ptr`），每个线程内部循环创建/销毁 SDK。
+
+---
+
+## 三、调用链路图
+
+```
+命令行参数 (host, port, ssl_type, group)
+  ↓
+bcos_sdk_create_config(is_sm_ssl, host, port)
+  ├── disable_ssl = 1               ← 跳过 SSL（压测优化）
+  ├── cert_config = {ca.crt, ...}   ← 证书路径
+  └── peers = [{host, port}]        ← 节点地址
+  ↓
+initWsConfig(config) → WsConfig
+  ├── setModel(Client)
+  ├── setConnectPeers(EndPoints)
+  ├── setDisableSsl / setThreadPoolSize / ...
+  └── setContextConfig (仅 !disable_ssl 时)
+  ↓
+SdkFactory::buildSdk(wsConfig, ...) → SDK
+  ↓
+sdk->jsonRpc()->getBlockNumber("group0", "", callback)
+  ↓  ↓  ↓  (100线程并发循环 ↑)
+  ↓  ↓  ↓
+sdk->stop() / sdk.reset()
+```
+
+---
+
+## 四、运行方法
+
+```bash
+./rpc 127.0.0.1 20200 ssl group0
+./rpc 127.0.0.1 20200 sm_ssl group0
+```
+
+| 参数 | 说明 |
+|------|------|
+| 127.0.0.1 | 节点 IP |
+| 20200 | 节点 RPC 端口 |
+| ssl / sm_ssl | SSL 类型（含子串匹配） |
+| group0 | 群组 ID |
+
+---
+
+## 五、与 deploy_hello 的关键差异
+
+| 对比维度 | deploy_hello | rpc_test |
+|---------|-------------|----------|
+| 配置来源 | INI 文件路径字符串 | 命令行 → C结构体 → WsConfig |
+| 实例数 | 1 个全局 SDK | 100 线程各建独立 SDK |
+| SSL | 标准证书校验 | `disable_ssl = 1` |
+| RPC 调用 | `jsonRpcService()->sendTransaction(...)` | `jsonRpc()->getBlockNumber(...)` |
+| SDK 生命周期 | 全程存活 | 每次创建/销毁 |
+
+---
+
+## 小结
+
+`rpc_test.cpp` 展示了绕过 INI 配置、纯代码构建 `WsConfig` 的完整流程。203 行覆盖了 **C 结构体工厂 → WsConfig::setConnectPeers/DisableSsl → SdkFactory::buildSdk → jsonRpc::getBlockNumber → 100 线程压测** 全链路。是理解底层 RPC 机制和性能压测的标准模板。

--- a/贡献内容/任务1-9-AMOP发布消息样例源码走读.md
+++ b/贡献内容/任务1-9-AMOP发布消息样例源码走读.md
@@ -1,0 +1,147 @@
+# AMOP 发布消息样例源码走读
+
+> **源码文件**: [publish.cpp](https://github.com/FISCO-BCOS/FISCO-BCOS/blob/master/bcos-sdk/sample/amop/publish.cpp)
+> **代码行数**: 107行
+> **核心功能**: 通过 AMOP 协议向指定 Topic 发布消息，并异步等待订阅方响应
+
+---
+
+## 任务目标
+
+讲清三个核心要点：**配置读取与 SDK 初始化**、**topic/message 参数的含义**、**发布回调的异步响应处理流程**。
+
+---
+
+## 一、源码结构总览
+
+| 行号范围 | 功能 |
+|---------|------|
+| 1-37 | 头文件引入 + namespace |
+| 40-47 | `usage()` 帮助信息 |
+| 49-69 | 参数校验 + SDK 初始化 |
+| 71-104 | **核心：while 循环中 `publish()` 调用** |
+
+---
+
+## 二、分步走读
+
+### 第1步：参数校验与 SDK 初始化（行49-69）
+
+```cpp
+// ./publish ./config_sample.ini topic msg
+// 三个参数均为必填
+if (argc < 4) {
+    usage();
+}
+
+std::string config = argv[1];
+std::string topic = argv[2];
+std::string msg = argv[3];
+
+auto factory = std::make_shared<SdkFactory>();
+auto sdk = factory->buildSdk(config);   // 字符串路径
+sdk->start();
+```
+
+消息参数 `msg` **必须提供**（`argc < 4`），没有默认值。
+
+### 第2步（核心）：publish() 循环发送（行71-103）
+
+```cpp
+while (true) {
+    sdk->amop()->publish(
+        topic,                                               // 1. Topic
+        bytesConstRef((byte*)msg.data(), msg.size()),        // 2. 消息体（零拷贝）
+        -1,                                                  // 3. 超时（-1=无限等待）
+        // ===== 异步回调（3 个参数）=====
+        [](Error::Ptr _error,
+           std::shared_ptr<WsMessage> _msg,
+           std::shared_ptr<WsSession> _session) {
+
+            if (_error) {
+                std::cout << "something is wrong"
+                          << " code: " << _error->errorCode()
+                          << " message: " << _error->errorMessage() << std::endl;
+                return;
+            }
+
+            if (_msg->status() != 0) {
+                std::cout << "something is wrong"
+                          << " status: " << _msg->status()
+                          << " message: " << std::string(_msg->payload()->begin(),
+                                                         _msg->payload()->end())
+                          << std::endl;
+                return;
+            }
+
+            std::cout << "recv response message ===>>>> "
+                      << std::string(_msg->payload()->begin(), _msg->payload()->end())
+                      << std::endl;
+        }
+    );
+    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+}
+```
+
+**关键点**：
+
+1. **SDK 在 while 循环外创建，循环内复用**——不是每次循环重建
+2. **回调只有 3 个参数**：`Error`、`WsMessage`、`WsSession`，无 `LocalTopic` 和 `P2PMessage`
+3. **超时 = -1**：无限等待订阅方响应
+4. **响应提取**：先检查 `_msg->status() != 0`，再通过 `_msg->payload()` 获取响应内容
+5. **间隔 5 秒**：`sleep_for(5000ms)` 控制发送频率
+
+---
+
+## 三、运行方法
+
+```bash
+./publish ./config_sample.ini myTopic "Hello from publisher"
+```
+
+| 参数 | 说明 |
+|------|------|
+| config_sample.ini | SDK 配置文件 |
+| myTopic | 目标 Topic 名称 |
+| "Hello from publisher" | 消息内容（必填） |
+
+---
+
+## 四、publish 调用流程图
+
+```
+main() → 解析 topic, msg
+  ↓
+SdkFactory::buildSdk(config) → sdk->start()     ← 只创建一次
+  ↓
+while(true):
+  amop()->publish(topic, bytesConstRef(msg), -1, callback)
+    │                                      ↓
+    │                          AMOP 发送消息到网络
+    │                                      ↓
+    │                          等待 subscribe 端匹配 Topic
+    │                                      ↓
+    ↓ 返回                         收到响应 → 触发 callback
+    │                                      ↓
+  sleep(5000ms)                          _error → 打印错误
+                                         _msg->status() → _msg->payload()
+                                              ↓
+                                         打印 "recv response message: ..."
+```
+
+---
+
+## 五、关键 API
+
+| API | 作用 |
+|-----|------|
+| `Sdk::amop()->publish(topic, data, timeout, callback)` | 发布消息并等待响应 |
+| `bytesConstRef(data, size)` | 零拷贝字节引用 |
+| `WsMessage::status()` | 响应状态，0 = 成功 |
+| `WsMessage::payload()` | 响应消息体，返回 `shared_ptr<bytes>` |
+
+---
+
+## 小结
+
+`publish.cpp` 展示了 AMOP 发布端实现：107 行覆盖 **topic/msg 必填 → 零拷贝发送 → 无限超时 → 3 参数回调提取响应** 的完整流程。SDK 在 while 外创建一次后循环复用，`status() != 0` 的判断不可省略。


### PR DESCRIPTION
## 简介

所有教程均基于 FISCO BCOS v3.x 主分支源码编写，每篇包含：源码结构总览 → 分步走读（含行号引用）→ 运行方法 → 流程图 → 关键 API 速查表 → 小结。代码引用均使用 GitHub 链接，无本地路径，符合开源社区贡献规范。

## 教程清单

| 任务 | 文件 | 源码文件 | 核心内容 |
|------|------|---------|---------|
| 1-3 | [FISCO BCOS 样例代码总览](贡献内容/任务1-3-FISCO-BCOS样例代码总览.md) | bcos-sdk/sample, fisco-bcos-demo, tools | 全局导航 + 四条学习路径 + 命令/API 速查 |
| 1-4 | [HelloWorld 合约部署源码走读](贡献内容/任务1-4-HelloWorld合约部署源码走读.md) | bcos-sdk/sample/tx/deploy_hello.cpp (298行) | 配置读取、SDK初始化、密钥生成、交易发送与回执解析 |
| 1-5 | [区块高度通知样例源码走读](贡献内容/任务1-5-区块高度通知样例源码走读.md) | bcos-sdk/sample/rpc/blocknotifier.cpp (88行) | BlockNotifier 注册、回调签名 `(const string&, int64_t)`、轮询循环 |
| 1-6 | [事件订阅样例源码走读](贡献内容/任务1-6-事件订阅样例源码走读.md) | bcos-sdk/sample/eventsub/eventsub.cpp (128行) | subscribeEvent 参数解析、回调中 `_events` 原始打印、notifier 注册顺序 |
| 1-7 | [RPC 调用发起流程教程](贡献内容/任务1-7-RPC调用发起流程教程.md) | bcos-sdk/sample/rpc/rpc_test.cpp (203行) | WsConfig 构建 (`setConnectPeers`)、`jsonRpc()->getBlockNumber()`、100 线程压测 |
| 1-9 | [AMOP 发布消息样例走读](贡献内容/任务1-9-AMOP发布消息样例源码走读.md) | bcos-sdk/sample/amop/publish.cpp (107行) | `argc<4` 必填校验、3 参数回调 `(Error, WsMessage, WsSession)`、SDK 复用模式 |
| 1-10 | [AMOP 订阅消息样例走读](贡献内容/任务1-10-AMOP订阅消息样例源码走读.md) | bcos-sdk/sample/amop/subscribe.cpp (101行) | `std::set` topic 去重、5 参数回调、`sendResponse()` 发送响应 |
| 1-11 | [AMOP 广播消息样例走读](贡献内容/任务1-11-AMOP广播消息样例源码走读.md) | bcos-sdk/sample/amop/broadcast.cpp (81行) | 广播 vs 发布对比、2 参数 `broadcast()` 无回调、SDK 一次创建 |
| 1-12 | [Echo Server 网络样例走读](贡献内容/任务1-12-Echo-Server网络样例源码走读.md) | fisco-bcos-demo/echo_server_sample.cpp (78行) | GatewayFactory 初始化、3 参数 P2P 回调、`setRespPacket()` 复用原消息 |

夏季开源成长营「成长路径一」
